### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: build
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/dus/security/code-scanning/3](https://github.com/deadjdona/dus/security/code-scanning/3)

To fix the problem, explicitly set a `permissions` block to restrict the `GITHUB_TOKEN` to the minimal scopes needed by this workflow. The `lint` job only needs to read repository contents. The `test` job also primarily needs read access, and the Coveralls action uses the token only to report coverage status back to GitHub (status checks/PRs) but does not itself require broad write access to repository contents. A good minimal, future-proof default is to set `permissions: contents: read` at the workflow root so it applies to both jobs, and then selectively grant any additional permissions only if/when necessary.

The single best way to fix this without changing existing functionality is to add a top-level `permissions` block just under the `name: build` line, with `contents: read`. This documents the workflow’s intent and ensures that the token cannot be used for unintended write operations to repository contents or other resources. If later you discover that Coveralls (or another step) needs additional scopes (such as `statuses: write`), that can be added explicitly, but with the information provided we’ll keep it minimal. Concretely, edit `.github/workflows/build.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 1. No imports or additional methods are needed, since this is purely a YAML configuration change within the GitHub Actions workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
