### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: release
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/dus/security/code-scanning/2](https://github.com/deadjdona/dus/security/code-scanning/2)

In general, the fix is to define an explicit `permissions:` block limiting the `GITHUB_TOKEN` to the least privileges needed. For this workflow, the current steps (checkout, setting up Python, building) only need read access to repository contents, so `contents: read` at the workflow or job level is sufficient. If in the future the publish‑to‑PyPI step is uncommented, it still won’t require repository write permissions because it authenticates via `secrets.PYPI_API_TOKEN`, not `GITHUB_TOKEN`.

The best minimal fix without changing existing functionality is to add a root‑level `permissions:` block directly under the `name:` (or under `on:`) so it applies to all jobs. We will set `contents: read`. This keeps behavior the same for any environment where the default was already read‑only, and reduces privileges in environments where the default was read‑write. Only `.github/workflows/release.yml` needs editing, and no additional imports or methods are required since this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
